### PR TITLE
[Chore]: Change articles page to blog

### DIFF
--- a/sanity/schemas/article.js
+++ b/sanity/schemas/article.js
@@ -111,5 +111,12 @@ export default {
       type: 'boolean',
       initialValue: false,
     },
+    {
+      name: 'listed',
+      description: 'Only listed artices will be visible to users',
+      title: 'Should this article be listed?',
+      type: 'boolean',
+      initialValue: true,
+    },
   ],
 };

--- a/src/app/(blog)/blog/[slug]/page.tsx
+++ b/src/app/(blog)/blog/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { PortableText } from '@portabletext/react';
 import { Metadata } from 'next';
-import React from 'react';
+import React, { cache } from 'react';
 import { MdTimer } from 'react-icons/md';
 
 import { formatDate } from '@/lib/helpers';
@@ -12,6 +12,10 @@ import { GET_ARTICLE } from '@/lib/queries';
 type Props = {
   params: Promise<{ slug: string }>;
 };
+
+const getArticle = cache(async (slug: string) => {
+  return await sanityClient.fetch<IArticle>(GET_ARTICLE, { slug });
+});
 
 export async function generateStaticParams() {
   const query = `*[_type == "post"] {
@@ -26,7 +30,7 @@ export async function generateStaticParams() {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const slug = (await params).slug;
-  const article = await sanityClient.fetch<IArticle>(GET_ARTICLE, { slug });
+  const article = await getArticle(slug);
 
   const title = article.title;
   const description = article.description;
@@ -35,6 +39,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     title,
     description,
     keywords: article.keyWords,
+    creator: article.author,
+    authors: { name: article.author },
     openGraph: {
       title,
       description,
@@ -46,9 +52,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 }
 
 const PostArticle = async ({ params }: Props) => {
-  const article = await sanityClient.fetch(GET_ARTICLE, {
-    slug: (await params).slug,
-  });
+  const slug = (await params).slug;
+
+  const article = await getArticle(slug);
 
   return (
     <div className="w-full md:max-w-xl lg:max-w-3xl mx-auto">
@@ -70,7 +76,7 @@ const PostArticle = async ({ params }: Props) => {
           {article.title}
         </h2>
 
-        <div className="py-4">
+        <div className="py-4 leading-7 text-[#171717]">
           <PortableText value={article.body as never} components={components} />
         </div>
       </div>

--- a/src/app/(blog)/blog/page.tsx
+++ b/src/app/(blog)/blog/page.tsx
@@ -20,8 +20,8 @@ const Articles = async () => {
     <div className="w-full lg:max-w-4xl 2xl:max-w-7xl mx-auto">
       <div className="min-h-screen py-12">
         <SectionHeader
-          title="Articles"
-          description="Enjoy my collected articles on different topics around blockchain, web performance, UI/UX design and many more."
+          title="Blog"
+          description="Enjoy my collected blog posts on different topics around blockchain, web performance, UI/UX design and many more."
           descriptionClassName="md:text-md 2xl:text-xl 5xl:text-3xl font-normal mt-3 text-center"
         />
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 my-12">

--- a/src/components/common/ArticleCard.tsx
+++ b/src/components/common/ArticleCard.tsx
@@ -16,7 +16,7 @@ type Props = {
 const ArticleCard = ({ article, className, isFeatured }: Props) => {
   return (
     <div className={cn('w-full h-full relative group', className)}>
-      <Link href={`/articles/${article.slug}`}>
+      <Link href={`/blog/${article.slug}`}>
         <div className="h-full border rounded-lg overflow-hidden relative z-[3]">
           <div
             className={cn('w-full h-52 lg:h-64', {

--- a/src/lib/helpers/constants.ts
+++ b/src/lib/helpers/constants.ts
@@ -7,7 +7,7 @@ export const MENU_ITEMS = [
 
 export const PAGE_HEADER_MENUS = [
   { name: 'Home', href: '/' },
-  { name: 'Articles', href: '/articles' },
+  { name: 'Blog', href: '/blog' },
   { name: 'Interactions', href: '/interactions' },
   { name: 'Projects', href: '/projects' },
   { name: 'Contact', href: '/#contact' },

--- a/src/lib/queries/index.ts
+++ b/src/lib/queries/index.ts
@@ -78,7 +78,7 @@ export const GET_METATAGS = `
 `;
 
 export const GET_ARTICLES = `
-     *[_type == "article"] {
+     *[_type == "article" && listed == true] | order(publishedOn desc) {
         _id,
         _ref,
         title,
@@ -90,6 +90,7 @@ export const GET_ARTICLES = `
         featured,
         readCount,
         publishedOn,
+        listed,
         "author": author -> name
     }
 `;

--- a/src/lib/serializers/article.tsx
+++ b/src/lib/serializers/article.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @next/next/no-img-element */
+
 import { PortableTextComponents } from '@portabletext/react';
 import Link from 'next/link';
 import { getImageDimensions } from '@sanity/asset-utils';
 import { codeToHtml } from 'shiki';
+import Image from 'next/image';
 
 import { urlFor } from '@/lib/helpers/sanity';
 import CopyButton from '@/components/common/CopyButton';
@@ -17,7 +18,7 @@ const ImageComponent = ({
 }) => {
   const { width, height } = getImageDimensions(value);
   return (
-    <img
+    <Image
       src={urlFor()
         .image(value)
         .width(isInline ? 100 : 800)
@@ -25,10 +26,11 @@ const ImageComponent = ({
         .auto('format')
         .url()}
       alt={value.alt || ' '}
+      width={width}
+      height={height}
       loading="lazy"
       style={{
         display: isInline ? 'inline-block' : 'block',
-        aspectRatio: width / height,
       }}
       className="my-4 mb-8"
     />
@@ -82,7 +84,9 @@ const components: PortableTextComponents = {
         {children}
       </h5>
     ),
-    normal: ({ children }) => <p className="text-base mt-4">{children}</p>,
+    normal: ({ children }) => (
+      <p style={{ marginTop: '1.25em', marginBottom: '1.25em' }}>{children}</p>
+    ),
   },
   list: {
     bullet: ({ children }) => (


### PR DESCRIPTION
- Changed the pathname from articles to blog
- Changed main titles of Articles to Blog
- Added a caching mechanism to only fetch article details once in generateMetadata and in RSC
- Improved the ordering of blogs by published date
- Added a listed flag to hide or show an article